### PR TITLE
Fix matplotlib dependency

### DIFF
--- a/empiricaldist/empiricaldist.py
+++ b/empiricaldist/empiricaldist.py
@@ -13,6 +13,7 @@ Copyright 2019 Allen B. Downey
 BSD 3-clause license: https://opensource.org/licenses/BSD-3-Clause
 """
 
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from scipy.interpolate import interp1d

--- a/empiricaldist/test_empiricaldist.py
+++ b/empiricaldist/test_empiricaldist.py
@@ -666,6 +666,15 @@ class Test(unittest.TestCase):
         for x in cdf.qs:
             self.assertAlmostEqual(cdf[x], cdf2[x])
 
+    def testPlotting(self):
+        t = [1, 2, 2, 3, 5]
+
+        pmf = Pmf.from_seq(t)
+        pmf.bar()
+
+        haz = Hazard.from_seq(t)
+        haz.bar()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,11 @@ def readme():
 
 setup(
     name="empiricaldist",
-    version="0.6.6",
+    version="0.6.7",
     author="Allen B. Downey",
     author_email="downey@allendowney.com",
     packages=["empiricaldist"],
-    requires=["numpy", "pandas", "scipy"],
+    requires=["matplotlib", "numpy", "pandas", "scipy"],
     url="https://github.com/AllenDowney/empiricaldist",
     license="BSD-3-Clause",
     description="Python library that represents empirical distributions.",


### PR DESCRIPTION
matplotlib was removed by commit dca787cf30656554b2488481bfb56099fc3a3102 in PR #21 from @dbready. Turns out it is required for the `bar()` plotting methods for classes `Pmf` and `Hazard`.

When I tried running the ThinkBayes2 notebooks, I kept getting the error:

```
NameError: name 'plt' is not defined
```

This PR adds back matplotlib and also adds automated tests to catch this type of regression in the future.