### PR TITLE
Make Pmf.copy() create deep copies by default

### DIFF
--- a/empiricaldist/empiricaldist.py
+++ b/empiricaldist/empiricaldist.py
@@ -353,7 +353,7 @@ class Distribution(pd.Series):
 class Pmf(Distribution):
     """Represents a probability Mass Function (PMF)."""
 
-    def copy(self, deep=False):
+    def copy(self, deep=True):
         """Make a copy.
 
         :return: new Pmf


### PR DESCRIPTION
`Pmf.copy()` was recently changed to create shallow copies by default: https://github.com/AllenDowney/empiricaldist/commit/e1c6cc9a903b613fa5e388719a73ae6968f25ac0

I suspect that change was unintentional, since creating a deep copy is a safer default, and it's what I would expect based on the method name. Also, all other classes in this library have a copy method that creates a deep copy by default.

Changing this back to creating deep copies will fix some code snippets in the Think Bayes book, and probably elsewhere too. I believe it is unlikely to break anything, since creating a deep copy is almost always what users of this method intend to do.